### PR TITLE
fixed incorrect term in table

### DIFF
--- a/Labs/Lab 5 Priority Queues/readme.md
+++ b/Labs/Lab 5 Priority Queues/readme.md
@@ -46,7 +46,7 @@ The Priority Queue has the same properties as the Queue in addition to the follo
 
 Lets compare the performance of a Queue with a Priority Queue:
 
-|         | Queue | Enqueue |
+|         | Queue | Priority |
 | :-----: | :---: | :-----: |
 | Enqueue | O(1)  |  O(n)   |   <----
 | Dequeue | O(1)  |  O(1)   |


### PR DESCRIPTION
in readme.md for Lab 5
the table should list queue vs priority [queue] where the live version of the site says Enqueue by mistake